### PR TITLE
タイヤ計算機-編集フォームの修正など

### DIFF
--- a/src/resources/views/layouts/navigation.blade.php
+++ b/src/resources/views/layouts/navigation.blade.php
@@ -165,15 +165,15 @@
                     {{ __('Dashboard') }}
                 </x-nav-link>
                 --}}
-                <x-nav-link :href="route('quote.index')" :active="request()->routeIs('quote.index')" class="text-nowrap">
+                <x-nav-link :href="route('quote.index')" :active="request()->routeIs('quote.*')" class="text-nowrap">
                     見積もり作成
                 </x-nav-link>
 
-                <x-nav-link :href="route('tirecalc.index')" :active="request()->routeIs('tirecalc.index')" class="text-nowrap">
+                <x-nav-link :href="route('tirecalc.index')" :active="request()->routeIs('tirecalc.*')" class="text-nowrap">
                     タイヤ計算機
                 </x-nav-link>
 
-                <x-nav-link :href="route('agecalc.index')" :active="request()->routeIs('agecalc.index')" class="text-nowrap">
+                <x-nav-link :href="route('agecalc.index')" :active="request()->routeIs('agecalc.*')" class="text-nowrap">
                     年齢計算機
                 </x-nav-link>
 
@@ -185,7 +185,7 @@
                     車両入替え送付状
                 </x-nav-link>
 
-                <x-nav-link :href="route('label.index')" :active="request()->routeIs('label.index')" class="text-nowrap">
+                <x-nav-link :href="route('label.index')" :active="request()->routeIs('label.*')" class="text-nowrap">
                     ラベル印刷
                 </x-nav-link>
 
@@ -197,7 +197,7 @@
                     売約済み（横書き）
                 </x-nav-link>
 
-                <x-nav-link :href="route('invoice.index')" :active="request()->routeIs('invoice.index')" class="text-nowrap">
+                <x-nav-link :href="route('invoice.index')" :active="request()->routeIs('invoice.*')" class="text-nowrap">
                     クイック請求書
                 </x-nav-link>
 

--- a/src/resources/views/tirecalc/edit.blade.php
+++ b/src/resources/views/tirecalc/edit.blade.php
@@ -168,10 +168,14 @@
                     <div class="flex gap-4">
                         <!-- 粗利A（加算） -->
                         <div class="w-1/2">
-                            <select x-model="grossA" class="w-full border rounded px-2 py-1">
+                            <select x-model.number="grossA" class="w-full border rounded px-2 py-1">
                                 <option :value="null">粗利（加算）</option>
                                 <template x-for="amount in [5000, 10000, 15000, 20000]" :key="amount">
-                                    <option :value="amount" x-text="`${amount.toLocaleString()} 円`"></option>
+                                    <option
+                                            :value="amount"
+                                            :selected="Number(grossA) === Number(amount)"
+                                            x-text="`${amount.toLocaleString()} 円`">
+                                    </option>
                                 </template>
                             </select>
                         </div>
@@ -181,7 +185,11 @@
                             <select x-model="grossB" class="w-full border rounded px-2 py-1">
                                 <option :value="null">粗利（乗算）</option>
                                 <template x-for="rate in [1.1, 1.2, 1.3, 1.4, 1.5]" :key="rate">
-                                    <option :value="rate" x-text="rate.toFixed(1)"></option>
+                                    <option
+                                            :value="rate"
+                                            :selected="Number(grossB) === Number(rate)"
+                                            x-text="`${rate.toFixed(1)}`">
+                                    </option>
                                 </template>
                             </select>
                         </div>
@@ -695,7 +703,7 @@
                     </button>
 
                     <!-- コピー ボタン -->
-                    <div x-data="taxCalculator()">
+                    <div>
                         <button type="button"
                             class="bg-gray-600 text-white px-4 py-2 rounded hover:bg-gray-700""
                         @click=" copyToClipboard">


### PR DESCRIPTION
## 修正内容
> ①editページで粗利のデータが引き込まれない
> ②editページで粗利を変更→「更新」しても更新されない
→ optionタグに:selectedを明示することで解消

> ③editページの時はメニューのテキストが青くならない
→ editページがある機能は、request()->routeIs('quote.*’)のように.*に変更してindex以外のルーティングにも反映されるように

> ④「コピー」で一部コピーできない
→ コピーボタンの親divに指定されていたx-data="taxCalculator()”により値が初期化されていたのでそれを削除