### PR TITLE
原価入力・粗利設定をCookieに自動保存

### DIFF
--- a/src/public/js/cookie.js
+++ b/src/public/js/cookie.js
@@ -1,0 +1,15 @@
+function setCookie(name, value, days) {
+  const expires = new Date(Date.now() + days * 864e5).toUTCString();
+  document.cookie = `${name}=${encodeURIComponent(value)}; expires=${expires}; path=/`;
+}
+
+function getCookie(name) {
+  return document.cookie.split('; ').reduce((r, v) => {
+    const parts = v.split('=');
+    return parts[0] === name ? decodeURIComponent(parts[1]) : r;
+  }, '');
+}
+
+function deleteCookie(name) {
+  setCookie(name, '', -1);
+}

--- a/src/resources/views/components/company-info.blade.php
+++ b/src/resources/views/components/company-info.blade.php
@@ -166,22 +166,6 @@
                     alert('クッキーから発信者情報を削除しました。');
                 }
             });
-
-            function setCookie(name, value, days) {
-                const expires = new Date(Date.now() + days * 864e5).toUTCString();
-                document.cookie = `${name}=${encodeURIComponent(value)}; expires=${expires}; path=/`;
-            }
-
-            function getCookie(name) {
-                return document.cookie.split('; ').reduce((r, v) => {
-                    const parts = v.split('=');
-                    return parts[0] === name ? decodeURIComponent(parts[1]) : r;
-                }, '');
-            }
-
-            function deleteCookie(name) {
-                setCookie(name, '', -1);
-            }
         </script>
         @endguest
 

--- a/src/resources/views/layouts/app.blade.php
+++ b/src/resources/views/layouts/app.blade.php
@@ -40,6 +40,7 @@
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/slick-carousel@1.8.1/slick/slick.css"/>
     <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/slick-carousel@1.8.1/slick/slick.min.js"></script>
+    <script src="{{ asset('/js/cookie.js') }}"></script>
 
     @livewireStyles
     @vite(['resources/css/app.css', 'resources/js/app.js'])

--- a/src/resources/views/layouts/guest.blade.php
+++ b/src/resources/views/layouts/guest.blade.php
@@ -12,6 +12,7 @@
         <link href="https://fonts.bunny.net/css?family=figtree:400,500,600&display=swap" rel="stylesheet" />
 
         <!-- Scripts -->
+        <script src="{{ asset('/js/cookie.js') }}"></script>
         @vite(['resources/css/app.css', 'resources/js/app.js'])
     </head>
     <body class="font-sans text-gray-900 antialiased">

--- a/src/resources/views/layouts/navigation.blade.php
+++ b/src/resources/views/layouts/navigation.blade.php
@@ -165,15 +165,15 @@
                     {{ __('Dashboard') }}
                 </x-nav-link>
                 --}}
-                <x-nav-link :href="route('quote.index')" :active="request()->routeIs('quote.index')" class="text-nowrap">
+                <x-nav-link :href="route('quote.index')" :active="request()->routeIs('quote.*')" class="text-nowrap">
                     見積もり作成
                 </x-nav-link>
 
-                <x-nav-link :href="route('tirecalc.index')" :active="request()->routeIs('tirecalc.index')" class="text-nowrap">
+                <x-nav-link :href="route('tirecalc.index')" :active="request()->routeIs('tirecalc.*')" class="text-nowrap">
                     タイヤ計算機
                 </x-nav-link>
 
-                <x-nav-link :href="route('agecalc.index')" :active="request()->routeIs('agecalc.index')" class="text-nowrap">
+                <x-nav-link :href="route('agecalc.index')" :active="request()->routeIs('agecalc.*')" class="text-nowrap">
                     年齢計算機
                 </x-nav-link>
 
@@ -185,7 +185,7 @@
                     車両入替え送付状
                 </x-nav-link>
 
-                <x-nav-link :href="route('label.index')" :active="request()->routeIs('label.index')" class="text-nowrap">
+                <x-nav-link :href="route('label.index')" :active="request()->routeIs('label.*')" class="text-nowrap">
                     ラベル印刷
                 </x-nav-link>
 
@@ -197,7 +197,7 @@
                     売約済み（横書き）
                 </x-nav-link>
 
-                <x-nav-link :href="route('invoice.index')" :active="request()->routeIs('invoice.index')" class="text-nowrap">
+                <x-nav-link :href="route('invoice.index')" :active="request()->routeIs('invoice.*')" class="text-nowrap">
                     クイック請求書
                 </x-nav-link>
 

--- a/src/resources/views/tirecalc/edit.blade.php
+++ b/src/resources/views/tirecalc/edit.blade.php
@@ -169,7 +169,7 @@
                         <!-- 粗利A（加算） -->
                         <div class="w-1/2">
                             <select x-model.number="grossA" class="w-full border rounded px-2 py-1">
-                                <option :value="null">粗利（加算）</option>
+                                <option value="">粗利（加算）</option>
                                 <template x-for="amount in [5000, 10000, 15000, 20000]" :key="amount">
                                     <option
                                             :value="amount"
@@ -183,7 +183,7 @@
                         <!-- 粗利B（掛け算） -->
                         <div class="w-1/2">
                             <select x-model="grossB" class="w-full border rounded px-2 py-1">
-                                <option :value="null">粗利（乗算）</option>
+                                <option value="">粗利（乗算）</option>
                                 <template x-for="rate in [1.1, 1.2, 1.3, 1.4, 1.5]" :key="rate">
                                     <option
                                             :value="rate"
@@ -425,15 +425,35 @@
                                 const sizeFree = document.getElementById('sizeFree')?.value;
                                 output += `■ タイヤサイズ\n${sizeFree || sizeGeneral || '未入力'}\n\n`;
 
+                                /**
+                                 * 商品情報
+                                 */
                                 const maker1 = document.getElementById('maker1')?.value || '未選択';
                                 const maker2 = document.getElementById('maker2')?.value || '未選択';
                                 const maker3 = document.getElementById('maker3')?.value || '未選択';
 
-                                output += `■ 商品1：${maker1}\n合計：${this.totalWithLabor(this.item1)} 円\n\n`;
-                                output += `■ 商品2：${maker2}\n合計：${this.totalWithLabor(this.item2)} 円\n\n`;
-                                output += `■ 商品3：${maker3}\n合計：${this.totalWithLabor(this.item3)} 円\n\n`;
+                                output += `■ 商品1：${maker1}\nタイヤ：${this.displayUnitPrice(this.item1).toLocaleString()} 円\n工賃：${this.laborSubtotal.toLocaleString()} 円\n合計：${this.totalWithLabor(this.item1).toLocaleString()} 円\n\n`;
+                                output += `■ 商品2：${maker2}\nタイヤ：${this.displayUnitPrice(this.item2).toLocaleString()} 円\n工賃：${this.laborSubtotal.toLocaleString()} 円\n合計：${this.totalWithLabor(this.item2).toLocaleString()} 円\n\n`;
+                                output += `■ 商品3：${maker3}\nタイヤ：${this.displayUnitPrice(this.item3).toLocaleString()} 円\n工賃：${this.laborSubtotal.toLocaleString()} 円\n合計：${this.totalWithLabor(this.item3).toLocaleString()} 円\n\n`;
 
-                                output += `■ 工賃明細\n小計：${this.laborSubtotal} 円\n\n`;
+                                /**
+                                 * 工賃詳細 - 動的に生成
+                                 */
+                                const laborLines = (this.laborItems || [])
+                                  // 名前と金額が入力されているもののみにフィルタリング
+                                  .filter(r => (r?.name ?? '').toString().trim() !== '' && Number(r?.price) > 0)
+                                  .map(r => {
+                                    const name = r.name; // 名前
+                                    const qty = Number(r?.quantity ?? 1); // 個数
+                                    const price = Number(r?.price ?? 0); // 金額
+                                    const amount = price * qty; // 合計
+                                    return `${name}：${amount.toLocaleString()} 円`;
+                                  })
+                                  .join('\n');
+
+                                output += `■ 工賃詳細\n${laborLines || '（未入力）'}\n` +
+                                  `税抜合計：${this.laborSubtotal.toLocaleString()} 円\n` +
+                                  `税込合計：${this.laborSubtotalExcludingTax.toLocaleString()} 円\n\n`;
 
                                 const comment = document.getElementById('comment')?.value || '';
                                 output += `■ コメント\n${comment.trim()}\n`;
@@ -705,8 +725,8 @@
                     <!-- コピー ボタン -->
                     <div>
                         <button type="button"
-                            class="bg-gray-600 text-white px-4 py-2 rounded hover:bg-gray-700""
-                        @click=" copyToClipboard">
+                            class="bg-gray-600 text-white px-4 py-2 rounded hover:bg-gray-700"
+                            @click="copyToClipboard">
                             コピー
                         </button>
                     </div>

--- a/src/resources/views/tirecalc/edit.blade.php
+++ b/src/resources/views/tirecalc/edit.blade.php
@@ -168,10 +168,14 @@
                     <div class="flex gap-4">
                         <!-- 粗利A（加算） -->
                         <div class="w-1/2">
-                            <select x-model="grossA" class="w-full border rounded px-2 py-1">
+                            <select x-model.number="grossA" class="w-full border rounded px-2 py-1">
                                 <option :value="null">粗利（加算）</option>
                                 <template x-for="amount in [5000, 10000, 15000, 20000]" :key="amount">
-                                    <option :value="amount" x-text="`${amount.toLocaleString()} 円`"></option>
+                                    <option
+                                            :value="amount"
+                                            :selected="Number(grossA) === Number(amount)"
+                                            x-text="`${amount.toLocaleString()} 円`">
+                                    </option>
                                 </template>
                             </select>
                         </div>
@@ -181,7 +185,11 @@
                             <select x-model="grossB" class="w-full border rounded px-2 py-1">
                                 <option :value="null">粗利（乗算）</option>
                                 <template x-for="rate in [1.1, 1.2, 1.3, 1.4, 1.5]" :key="rate">
-                                    <option :value="rate" x-text="rate.toFixed(1)"></option>
+                                    <option
+                                            :value="rate"
+                                            :selected="Number(grossB) === Number(rate)"
+                                            x-text="`${rate.toFixed(1)}`">
+                                    </option>
                                 </template>
                             </select>
                         </div>
@@ -695,7 +703,7 @@
                     </button>
 
                     <!-- コピー ボタン -->
-                    <div x-data="taxCalculator()">
+                    <div>
                         <button type="button"
                             class="bg-gray-600 text-white px-4 py-2 rounded hover:bg-gray-700""
                         @click=" copyToClipboard">

--- a/src/resources/views/tirecalc/index.blade.php
+++ b/src/resources/views/tirecalc/index.blade.php
@@ -63,11 +63,11 @@
                         <div class="mb-4">
                             <h3 class="text-xl font-bold mb-1">①原価入力</h3>
                             <label class="inline-flex items-center mr-4">
-                                <input type="radio" x-model="taxMode" value="including" class="mr-1">
+                                <input type="radio" x-model="taxMode" value="including" class="mr-1 taxMode">
                                 税込み
                             </label>
                             <label class="inline-flex items-center">
-                                <input type="radio" x-model="taxMode" value="excluding" class="mr-1">
+                                <input type="radio" x-model="taxMode" value="excluding" class="mr-1 taxMode">
                                 税抜き
                             </label>
                         </div>
@@ -78,11 +78,11 @@
                             <div class="flex gap-4">
                                 <div class="w-[70%]">
 
-                                    <input type="number" x-model.number="item1.cost" min="0" placeholder="商品Aの原価" class="w-full border rounded px-2 py-1">
+                                    <input type="number" x-model.number="item1.cost" min="0" placeholder="商品Aの原価" class="w-full border rounded px-2 py-1" id="cost1">
                                 </div>
                                 <div class="w-[30%]">
 
-                                    <select x-model.number="item1.quantity" class="w-full border rounded px-2 py-1">
+                                    <select x-model.number="item1.quantity" class="w-full border rounded px-2 py-1" id="quantity1">
                                         <option value="1">1個</option>
                                         <option value="2">2個</option>
                                         <option value="3">3個</option>
@@ -107,11 +107,11 @@
                             <div class="flex gap-4">
                                 <div class="w-[70%]">
 
-                                    <input type="number" x-model.number="item2.cost" min="0" placeholder="商品Bの原価" class="w-full border rounded px-2 py-1">
+                                    <input type="number" x-model.number="item2.cost" min="0" placeholder="商品Bの原価" class="w-full border rounded px-2 py-1" id="cost2">
                                 </div>
                                 <div class="w-[30%]">
 
-                                    <select x-model.number="item2.quantity" class="w-full border rounded px-2 py-1">
+                                    <select x-model.number="item2.quantity" class="w-full border rounded px-2 py-1" id="quantity2">
                                         <option value="1">1個</option>
                                         <option value="2">2個</option>
                                         <option value="3">3個</option>
@@ -137,11 +137,11 @@
                             <div class="flex gap-4">
                                 <div class="w-[70%]">
 
-                                    <input type="number" x-model.number="item3.cost" min="0" placeholder="商品Cの原価" class="w-full border rounded px-2 py-1">
+                                    <input type="number" x-model.number="item3.cost" min="0" placeholder="商品Cの原価" class="w-full border rounded px-2 py-1" id="cost3">
                                 </div>
                                 <div class="w-[30%]">
 
-                                    <select x-model.number="item3.quantity" class="w-full border rounded px-2 py-1">
+                                    <select x-model.number="item3.quantity" class="w-full border rounded px-2 py-1" id="quantity3">
                                         <option value="1">1個</option>
                                         <option value="2">2個</option>
                                         <option value="3">3個</option>
@@ -172,7 +172,7 @@
                             <div class="flex gap-4">
                                 <!-- 粗利A（加算） -->
                                 <div class="w-1/2">
-                                    <select x-model="grossA" class="w-full border rounded px-2 py-1">
+                                    <select x-model="grossA" class="w-full border rounded px-2 py-1" id="grossA">
                                         <option :value="null">粗利（加算）</option>
                                         <template x-for="amount in [5000, 10000, 15000, 20000]" :key="amount">
                                             <option :value="amount" x-text="`${amount.toLocaleString()} 円`"></option>
@@ -182,7 +182,7 @@
 
                                 <!-- 粗利B（掛け算） -->
                                 <div class="w-1/2">
-                                    <select x-model="grossB" class="w-full border rounded px-2 py-1">
+                                    <select x-model="grossB" class="w-full border rounded px-2 py-1" id="grossB">
                                         <option :value="null">粗利（乗算）</option>
                                         <template x-for="rate in [1.1, 1.2, 1.3, 1.4, 1.5]" :key="rate">
                                             <option :value="rate" x-text="rate.toFixed(1)"></option>
@@ -533,13 +533,6 @@
             </div>
         </div>
 
-
-
-
-
-
-
-
         <!-- Alpine.js ロジック -->
         <script>
             function taxCalculator() {
@@ -725,6 +718,63 @@
             }
         </script>
 
+        <!-- Cookieに自動保存 & 初期値反映 -->
+        <script>
+          // 自動保存する項目のIDを設定 (input, select)
+          const auto_save_fields = [
+            'cost1', 'quantity1', 'cost2', 'quantity2', 'cost3', 'quantity3', 'grossA', 'grossB'
+          ];
+          // 自動保存する項目のクラスを設定 (radio)
+          const auto_save_radio_fields = [
+            'taxMode'
+          ];
 
+          // input, selectの変更を保存
+          auto_save_fields.forEach(field => {
+            const input = document.getElementById(field);
+            if (input) {
+              input.addEventListener('input', function() {
+                setCookie(field, this.value, 30);
+              });
+            }
+          });
+          // radioの変更を保存
+          auto_save_radio_fields.forEach(field => {
+            const radios = document.querySelectorAll(`input[type="radio"].${field}`);
+            if (radios.length) {
+              radios.forEach((r) => {
+                r.addEventListener('change', function () {
+                  // チェックされている場合は保存
+                  if (this.checked) setCookie(field, this.value, 30);
+                });
+              });
+            }
+          });
 
+          window.addEventListener('DOMContentLoaded', () => {
+            // input, selectの初期値反映
+            auto_save_fields.forEach(field => {
+              const value = getCookie(field);
+              const input = document.getElementById(field);
+              if (input && value) {
+                input.value = value;
+                const event = input.tagName === 'SELECT' ? 'change' : 'input';
+                input.dispatchEvent(new Event(event, { bubbles: true }));
+              }
+            });
+            // radioの初期値反映
+            auto_save_radio_fields.forEach(field => {
+              const value = getCookie(field);
+              const radios = document.querySelectorAll(`input[type="radio"].${field}`);
+              if (radios.length && value) {
+                const is_checked = Array.from(radios).find(r => r.value == value);
+                if (is_checked) {
+                  is_checked.checked = true;
+                  is_checked.dispatchEvent(new Event('change', { bubbles: true }));
+                  return;
+                }
+              }
+            });
+          });
+        </script>
 </x-app-layout>


### PR DESCRIPTION
## 実装内容
原価入力・粗利設定変更時にCookieに自動保存 & 初期値に反映 (新規作成のみ)

## 備考
- Cookieを扱う処理は、既存の`components/company-info.blade.php`でも使用していたため、`public/js/cookie.js`に共通関数を切り出しました。これにより関数を毎回宣言しなくとも、cookie.jsを読み込むだけで使用可能になります。
- 保存 & 反映処理は`tirecalc/index.blade.php`の721行目`-- Cookieに自動保存 & 初期値反映 --` からご参照ください。随所のdispatchEventによりAlphine.jsに変更を反映して再計算を促しています。